### PR TITLE
Address: Added API functionalities

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,3 @@
+# GoLang Komodo API Repository
+
+Still under construction

--- a/README.md
+++ b/README.md
@@ -1,3 +1,22 @@
-# GoLang Komodo API Repository
+# GoLang Komodo API 
 
-Still under construction
+Still Under Construction
+
+## Getting Started
+```go
+func main(){
+    authentication := &komodo.Auth{
+        Password: "",
+        User: "",
+        Port: 9009,
+    }
+    client:=komodo.Client{Auth: authentication}
+    parameter := komodo.Params{
+        "addresses": []string{"RTTg3izdeVnqkTTxjzsPFrdUQexgqCy1qb"}
+        "start": 1,
+        "end": 200,
+        "chaininfo": true,
+    }
+    client.GenerateAddressDeltas(parameter)
+}
+```

--- a/address.go
+++ b/address.go
@@ -1,5 +1,55 @@
 package komodo
 
-func getAddress() {
+import (
+	"net/http"
+)
 
+// GetAddressBalance returns the balance in the current address
+func (c *Client) GetAddressBalance(param Params) (*http.Response, error) {
+	if body, err := c.generateCurl("getaddressbalance", nil); err != nil {
+		return nil, err
+	} else {
+		return c.send(body)
+	}
+}
+
+func (c *Client) GetAddressDeltas(params Params) (*http.Response, error) {
+	if body, err := c.generateCurl("getaddressbalance", params); err != nil {
+		return nil, err
+	} else {
+		return c.send(body)
+	}
+}
+
+func (c *Client) GetAddressMempool(address string) (*http.Response, error) {
+	if body, err := c.generateCurl("getaddressmempool", nil); err != nil {
+		return nil, err
+	} else {
+		return c.send(body)
+	}
+}
+
+func (c *Client) GetAddressTXIDS(address string, params ...Params) (*http.Response, error) {
+	if body, err := c.generateCurl("getaddresstxids", nil); err != nil {
+		return nil, err
+	} else {
+		return c.send(body)
+	}
+}
+
+func (c *Client) GetAddressUTXOS(address string, params ...Params) (*http.Response, error) {
+	if body, err := c.generateCurl("getaddressutxos", nil); err != nil {
+		return nil, err
+	} else {
+		return c.send(body)
+	}
+}
+
+// TODO: needs to be tested. No address is passed
+func (c *Client) GetSnapShot(params Params) (*http.Response, error) {
+	if body, err := c.generateCurl("getsnapshot", nil); err != nil {
+		return nil, err
+	} else {
+		return c.send(body)
+	}
 }

--- a/address.go
+++ b/address.go
@@ -1,0 +1,5 @@
+package komodo
+
+func getAddress() {
+
+}

--- a/base.go
+++ b/base.go
@@ -1,0 +1,76 @@
+package komodo
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"os"
+	"strings"
+)
+
+type Auth struct {
+	Password string `json:"password"`
+	User     string `json:"user"`
+	Port     int    `json:"port"`
+}
+
+type Client struct {
+	*Auth
+	Request *http.Request
+}
+
+type dataBinary struct {
+	Json   string `json:"json"`
+	ID     string `json:"id"`
+	Method string `json:"method"`
+	Params Params `json:"params,omitempty"`
+}
+
+type Params map[string]interface{}
+
+// KomodoClient returns a new komodo client
+// filePath of the json file that contains the authentication
+// details
+func KomodoClient(filePath string) *Client {
+	var auth = &Auth{}
+	var data []byte
+	file, err := os.Open(filePath)
+	if err != nil {
+
+	}
+	file.Read(data)
+	if err := json.Unmarshal(data, auth); err != nil {
+
+	}
+	return &Client{Auth: auth}
+}
+
+func (c *Client) send(body *strings.Reader) (*http.Response, error) {
+	request, err := http.NewRequest("POST", "http://127.0.0.1:"+string(c.Port), body)
+	if err != nil {
+		return nil, nil
+	}
+	request.SetBasicAuth(c.User, c.Password)
+	request.Header.Set("Content-Type", "text/plain;")
+	resp, err := http.DefaultClient.Do(request)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	return resp, err
+}
+
+func (c *Client) generateCurl(method string, params Params) (*strings.Reader, error) {
+	data := &dataBinary{
+		Json:   "1.0",
+		ID:     "curltest",
+		Method: method,
+		Params: params,
+	}
+	d, err := json.Marshal(data)
+	fmt.Println(string(d))
+	if err != nil {
+		return nil, fmt.Errorf("could not marshal method and paramerters")
+	}
+	return strings.NewReader(string(d)), nil
+}


### PR DESCRIPTION
This commit adds address api functionalities. A new `base.go` file has been added. 

`base.go` file has functionalities to generate a data-binary and make a http request to the Komodo server. The `send()` function makes a http request. `GenerateCurl()` generates the data-binary contents.