### PR TITLE
Address: Adds Address RPC Calls

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,3 @@
+# GoLang Komodo API Repository
+
+Still under construction

--- a/README.md
+++ b/README.md
@@ -1,3 +1,22 @@
-# GoLang Komodo API Repository
+# GoLang Komodo API 
 
-Still under construction
+Still Under Construction
+
+## Getting Started
+```go
+func main(){
+    authentication := &komodo.Auth{
+        Password: "",
+        User: "",
+        Port: 9009,
+    }
+    client:=komodo.Client{Auth: authentication}
+    parameter := komodo.Params{
+        "addresses": []string{"RTTg3izdeVnqkTTxjzsPFrdUQexgqCy1qb"}
+        "start": 1,
+        "end": 200,
+        "chaininfo": true,
+    }
+    client.GenerateAddressDeltas(parameter)
+}
+```

--- a/address.go
+++ b/address.go
@@ -1,0 +1,5 @@
+package komodo
+
+func getAddress() {
+
+}

--- a/address.go
+++ b/address.go
@@ -1,5 +1,67 @@
 package komodo
 
-func getAddress() {
+import "encoding/json"
 
+// GetAddressBalance method returns the confirmed balance for an address, or addresses.
+// It requires addressindex to be enabled.
+/*
+	Params:
+		address (string) - the address
+	Returns:
+		GetWalletInfo
+		error
+*/
+func (c *Client) GetAddressBalance(params Params) (*GetWalletInfo, error) {
+	data, err := c.send("getaddressbalance", params)
+	if err != nil {
+		return nil, err
+	}
+	var v = &GetWalletInfo{}
+	return v, json.Unmarshal(data, v)
+}
+
+func (c *Client) GetAddressDeltas(params Params) (*GetAddressDeltas, error) {
+	data, err := c.send("getaddressdeltas", params)
+	if err != nil {
+		return nil, err
+	}
+	var v = &GetAddressDeltas{}
+	return v, json.Unmarshal(data, v)
+}
+
+func (c *Client) GetAddressMempool(params Params) (*GetAddressMemPool, error) {
+	data, err := c.send("getaddressmempool", params)
+	if err != nil {
+		return nil, err
+	}
+	var v = &GetAddressMemPool{}
+	return v, json.Unmarshal(data, v)
+}
+
+func (c *Client) GetAddressTXIDS(params Params) (*GetAddressTXIDs, error) {
+	data, err := c.send("getaddresstxids", params)
+	if err != nil {
+		return nil, err
+	}
+	var v = &GetAddressTXIDs{}
+	return v, json.Unmarshal(data, v)
+}
+
+func (c *Client) GetAddressUTXOS(params Params) (*GetAddressUTXOs, error) {
+	data, err := c.send("getaddressutxos", params)
+	if err != nil {
+		return nil, err
+	}
+	var v = &GetAddressUTXOs{}
+	return v, json.Unmarshal(data, v)
+}
+
+// TODO: needs to be tested. No address is passed
+func (c *Client) GetSnapShot() (*GetSnapshot, error) {
+	data, err := c.send("getsnapshot", nil)
+	if err != nil {
+		return nil, err
+	}
+	var v = &GetSnapshot{}
+	return v, json.Unmarshal(data, v)
 }

--- a/base.go
+++ b/base.go
@@ -1,0 +1,85 @@
+package komodo
+
+import (
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"os"
+	"strconv"
+	"strings"
+)
+
+type Auth struct {
+	Host     string `json:"host"`
+	User     string `json:"user"`
+	Password string `json:"password"`
+	Port     int    `json:"port"`
+}
+
+type Client struct {
+	*Auth
+	Request *http.Request
+}
+
+type dataBinary struct {
+	JSON   string `json:"jsonrpc"`
+	ID     string `json:"id"`
+	Method string `json:"method"`
+	Params Params `json:"params,omitempty"`
+}
+
+type Params map[string]interface{}
+
+// KomodoClient returns a new komodo client
+// filePath of the json file that contains the authentication
+// details
+func NewClient(filePath string) (*Client, error) {
+	var auth = &Auth{}
+	var data []byte
+	file, err := os.Open(filePath)
+	if err != nil {
+		return nil, err
+	}
+	if _, err = file.Read(data); err != nil {
+		return nil, err
+	}
+	if err := json.Unmarshal(data, auth); err != nil {
+		return nil, err
+	}
+	return &Client{Auth: auth}, nil
+}
+
+func (c *Client) send(method string, params Params) ([]byte, error) {
+	body, err := c.generateCurl(method, params)
+	if err != nil {
+		return nil, err
+	}
+	host := fmt.Sprintf("http://%s:%s/", c.Host, strconv.Itoa(c.Port))
+	request, err := http.NewRequest("POST", host, body)
+	if err != nil {
+		return nil, err
+	}
+	request.SetBasicAuth(c.User, c.Password)
+	request.Header.Set("Content-Type", "text/plain;")
+	resp, err := http.DefaultClient.Do(request)
+	if err != nil {
+		return nil, err
+	}
+	d, err := ioutil.ReadAll(resp.Body)
+	return d, err
+}
+
+func (c *Client) generateCurl(method string, params Params) (*strings.Reader, error) {
+	data := &dataBinary{
+		JSON:   "1.0",
+		ID:     "curltest",
+		Method: method,
+		Params: params,
+	}
+	d, err := json.Marshal(data)
+	if err != nil {
+		return nil, fmt.Errorf("could not marshal method and paramerters")
+	}
+	return strings.NewReader(string(d)), nil
+}

--- a/types.go
+++ b/types.go
@@ -1,0 +1,94 @@
+package komodo
+
+type GetWalletInfo struct {
+	Result struct {
+		WalletVersion      int32   `json:"walletversion"`
+		Balance            float32 `json:"balance"`
+		UnconfirmedBalance float32 `json:"unconfirmed_balance"`
+		ImmatureBalance    float32 `json:"immature_balance"`
+		TXCount            int32   `json:"txcount"`
+		KeyPoolOldest      int64   `json:"keypoololdest"`
+		KeyPoolSize        int32   `json:"keypoolsize"`
+		PatTXFee           float32 `json:"paytxfee"`
+		SeedFP             string  `json:"seedfp"`
+	}
+	Common
+}
+
+type GetAddressBalance struct {
+	Result struct {
+		Balance  int32 `json:"balance"`
+		Received int32 `json:"received"`
+	}
+	Common
+}
+
+type GetAddressDeltas struct {
+	Result struct {
+		Satoshis int32  `json:"satoshis"`
+		TXID     string `json:"txid"`
+		Index    int32  `json:"index"`
+		Height   int32  `json:"height"`
+		Address  string `json:"address"`
+	}
+	Common
+}
+
+type GetAddressMemPool struct {
+	Result struct {
+		Address   string `json:"address"`
+		TXID      string `json:"txid"`
+		Index     int32  `json:"index"`
+		Satoshis  int32  `json:"satoshis"`
+		Timestamp int32  `json:"timestamp"`
+		PrevTXID  string `json:"prevtxid"`
+		PrevOut   string `json:"prevout"`
+	}
+	Common
+}
+
+type GetAddressTXIDs struct {
+	Result struct {
+		TransactionID string `json:"transaction_id"`
+	}
+	Common
+}
+
+type GetAddressUTXOs struct {
+	Result struct {
+		Address     string `json:"address"`
+		TXID        string `json:"txid"`
+		Height      int32  `json:"height"`
+		OutputIndex int32  `json:"outputIndex"`
+		Script      string `json:"script"`
+		Satoshis    int32  `json:"satoshis"`
+	}
+	Common
+}
+
+type GetSnapshot struct {
+	Result struct {
+		Addresses      Addresses `json:"addresses"`
+		Address        string    `json:"addr"`
+		Amount         float32   `json:"amount"`
+		Total          float32   `json:"total"`
+		Average        int32     `json:"average"`
+		UTXOS          int32     `json:"utxos"`
+		TotalAddresses int32     `json:"total_addresses"`
+		StartHeight    int32     `json:"start_height"`
+		EndingHeight   int32     `json:"ending_height"`
+		StartTime      int32     `json:"start_time"`
+		EndTime        int32     `json:"end_time"`
+	}
+	Common
+}
+
+type Addresses struct {
+	Address string `json:"addr"`
+	Amount  string `json:"amount"`
+	SegID   int32  `json:"segid"`
+}
+type Common struct {
+	Error interface{} `json:"error"`
+	ID    string      `json:"id"`
+}


### PR DESCRIPTION
Adds RPC calls realated to address. All response received from the komodo
server are parsed to its own type.

Type details can be found in the `types.go` file.

Developers can create obtain a new client two ways. First would be to create
an `Authentication` type and populate the related fields. An other way would
be to create a `auth.json` with a json structure similar to `authentication`
type.